### PR TITLE
Add option to only watch changed files

### DIFF
--- a/jest.novaextension/CHANGELOG.md
+++ b/jest.novaextension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.3.0
+
+### Added
+
+- Add option to only run tests for changed files. Requires project to be a Git repository.
+
 ## v1.2.2
 
 ### Fixed

--- a/jest.novaextension/extension.json
+++ b/jest.novaextension/extension.json
@@ -24,6 +24,13 @@
       "description": "A path to to a Jest executable for a custom or global installation. Example: frontend/node_modules/.bin/jest",
       "type": "path",
       "relative": true
+    },
+    {
+      "key": "apexskier.jest.config.onlyChanged",
+      "title": "Run tests only for changed files",
+      "description": "Requires project to be a Git repository",
+      "type": "boolean",
+      "default": false
     }
   ],
 

--- a/jest.novaextension/extension.json
+++ b/jest.novaextension/extension.json
@@ -3,7 +3,7 @@
   "name": "Jest",
   "organization": "Cameron Little",
   "description": "Jest test framework integration",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "categories": ["issues", "sidebars"],
   "license": "MIT",
   "repository": "https://github.com/apexskier/nova-jest",
@@ -50,6 +50,18 @@
       "allowFiles": false,
       "allowFolders": true,
       "relative": true
+    },
+    {
+      "key": "apexskier.jest.config.onlyChanged",
+      "title": "Run tests only for changed files",
+      "description": "Requires project to be a Git repository",
+      "type": "enum",
+      "values": [
+        ["inherit", "Inherit from Global Settings"],
+        ["true", "Enable"],
+        ["false", "Disable"]
+      ],
+      "default": "inherit"
     }
   ],
 

--- a/src/jestWatchMode.test.ts
+++ b/src/jestWatchMode.test.ts
@@ -1,0 +1,35 @@
+import { getJestWatchMode } from "./jestWatchMode";
+
+(global as any).nova = Object.assign(nova, {
+  config: {
+    get: () => false,
+  },
+  workspace: {
+    relativizePath: () => __dirname,
+  },
+});
+
+describe("watch mode setting", () => {
+  it("uses watchAll mode if option is disabled", () => {
+    (nova as any).config.get = () => false;
+    expect(getJestWatchMode()).toBe("--watchAll");
+  });
+
+  it("uses watchAll mode if option is enabled but project is not a git repository", () => {
+    (nova as any).config.get = () => true;
+    (nova as any).workspace.contains = () => false;
+    expect(getJestWatchMode()).toBe("--watchAll");
+  });
+
+  it("uses watchAll mode if project is a git repository but option is disabled", () => {
+    (nova as any).config.get = () => false;
+    (nova as any).workspace.contains = () => true;
+    expect(getJestWatchMode()).toBe("--watchAll");
+  });
+
+  it("uses watch mode if option is enabled and project is a git repository", () => {
+    (nova as any).config.get = () => true;
+    (nova as any).workspace.contains = () => true;
+    expect(getJestWatchMode()).toBe("--watch");
+  });
+});

--- a/src/jestWatchMode.test.ts
+++ b/src/jestWatchMode.test.ts
@@ -6,22 +6,26 @@ import { getJestWatchMode } from "./jestWatchMode";
   },
   workspace: {
     relativizePath: () => __dirname,
+    config: {
+      get: () => "inherit",
+    },
+    // `contains` used to check presence of a `.git` folder, ensuring a Git project
+    contains: () => true,
   },
 });
 
-describe("watch mode setting", () => {
-  it("uses watchAll mode if option is disabled", () => {
-    (nova as any).config.get = () => false;
+describe("'watch' mode setting", () => {
+  it("uses 'watchAll' mode if option is disabled", () => {
     expect(getJestWatchMode()).toBe("--watchAll");
   });
 
-  it("uses watchAll mode if option is enabled but project is not a git repository", () => {
+  it("uses 'watchAll' mode if option is enabled but project is not a git repository", () => {
     (nova as any).config.get = () => true;
     (nova as any).workspace.contains = () => false;
     expect(getJestWatchMode()).toBe("--watchAll");
   });
 
-  it("uses watchAll mode if project is a git repository but option is disabled", () => {
+  it("uses 'watchAll' mode if project is a git repository but option is disabled", () => {
     (nova as any).config.get = () => false;
     (nova as any).workspace.contains = () => true;
     expect(getJestWatchMode()).toBe("--watchAll");
@@ -31,5 +35,35 @@ describe("watch mode setting", () => {
     (nova as any).config.get = () => true;
     (nova as any).workspace.contains = () => true;
     expect(getJestWatchMode()).toBe("--watch");
+  });
+
+  describe("workspace option overrides global option", () => {
+    it("inherit option - disabled", () => {
+      (nova as any).config.get = () => false;
+      (nova as any).workspace.contains = () => true;
+      (nova as any).workspace.config.get = () => "inherit";
+      expect(getJestWatchMode()).toBe("--watchAll");
+    });
+
+    it("inherit option - enabled", () => {
+      (nova as any).config.get = () => true;
+      (nova as any).workspace.contains = () => true;
+      (nova as any).workspace.config.get = () => "inherit";
+      expect(getJestWatchMode()).toBe("--watch");
+    });
+
+    it("overrides global option - disabled", () => {
+      (nova as any).config.get = () => false;
+      (nova as any).workspace.contains = () => true;
+      (nova as any).workspace.config.get = () => "true";
+      expect(getJestWatchMode()).toBe("--watch");
+    });
+
+    it("overrides global option - enabled", () => {
+      (nova as any).config.get = () => true;
+      (nova as any).workspace.contains = () => true;
+      (nova as any).workspace.config.get = () => "false";
+      expect(getJestWatchMode()).toBe("--watchAll");
+    });
   });
 });

--- a/src/jestWatchMode.ts
+++ b/src/jestWatchMode.ts
@@ -2,12 +2,27 @@ const isGitProject = (): boolean => {
   return nova.workspace.contains(nova.workspace.relativizePath("/.git"));
 };
 
+function getWorkspaceSetting(): boolean | null {
+  const setting = nova.workspace.config.get(
+    "apexskier.jest.config.onlyChanged",
+    "string"
+  );
+
+  switch (setting) {
+    case "true":
+      return true;
+    case "false":
+      return false;
+    default:
+      return null;
+  }
+}
+
 // Get the Jest Watch mode flag
 export function getJestWatchMode(): string {
-  const configJestOnlyChanged = nova.config.get(
-    "apexskier.jest.config.onlyChanged",
-    "boolean"
-  );
+  const configJestOnlyChanged =
+    getWorkspaceSetting() ??
+    nova.config.get("apexskier.jest.config.onlyChanged", "boolean");
 
   // If option enabled, ensure that project is a git repository
   return configJestOnlyChanged && isGitProject() ? "--watch" : "--watchAll";

--- a/src/jestWatchMode.ts
+++ b/src/jestWatchMode.ts
@@ -1,0 +1,14 @@
+const isGitProject = (): boolean => {
+  return nova.workspace.contains(nova.workspace.relativizePath("/.git"));
+};
+
+// Get the Jest Watch mode flag
+export function getJestWatchMode(): string {
+  const configJestOnlyChanged = nova.config.get(
+    "apexskier.jest.config.onlyChanged",
+    "boolean"
+  );
+
+  // If option enabled, ensure that project is a git repository
+  return configJestOnlyChanged && isGitProject() ? "--watch" : "--watchAll";
+}

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -24,6 +24,9 @@ jest.mock("./jestWorkingDirectory", () => ({
   },
   workspace: {
     path: "/workspace",
+    config: {
+      get: () => "inherit",
+    },
   },
   extension: {
     path: "/extension",

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -19,6 +19,9 @@ jest.mock("./jestWorkingDirectory", () => ({
   commands: {
     register: jest.fn(),
   },
+  config: {
+    get: () => false,
+  },
   workspace: {
     path: "/workspace",
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { wrapCommand } from "./novaUtils";
 import { InformationView } from "./informationView";
 import { getJestExecPath } from "./jestExecPath";
+import { getJestWatchMode } from "./jestWatchMode";
 import { getJestWorkingDir } from "./jestWorkingDirectory";
 import { TestResultsManager } from "./testResults";
 
@@ -80,7 +81,7 @@ async function asyncActivate() {
   // jest process will continually run
   const jestProcess = new Process(jestExecPath, {
     args: [
-      "--watchAll",
+      getJestWatchMode(),
       "--testLocationInResults",
       "--reporters",
       nova.path.join(nova.extension.path, "Scripts/reporter.dist.js"),


### PR DESCRIPTION
Hello again 👋 This PR Closes #39, I've also added check to fall back to `--watchAll` in case the workspace isn't a Git repository.

One thing to note is that I couldn't find a good way to get a workspace wide setting working along with a global one.
The `config.get` calls seem to always return a boolean value (even with coercion) turned off. This made it impossible to have the setting enabled globally, but then disabled on a per project basis. Not too familiar with Nova APIs yet though, so I'd be happy to be shown otherwise :)
One potential solution is to allow users to pass in a string value instead of a checkbox. A little worse ergonomically, but opens up the full power of custom settings.

Let me know if you'd like me to make any changes.

Here's what it looks like:
<img width="813" alt="Screenshot 2020-11-01 at 16 58 04@2x" src="https://user-images.githubusercontent.com/1646307/97816550-09b38780-1c64-11eb-838b-223e40fe4147.png">

